### PR TITLE
Add Drush logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A simple PSR-3 implementation of a logger for Drupal watchdog calls.
+A collection of simple PSR-3 implementations of loggers for Drupal watchdog and Drush log calls.
 
 # Details
 
@@ -14,7 +14,7 @@ The PSR-3 parameter ```$context``` is passed to watchdog as variables, for use a
         }
     }
 
-The watch dog type is set as the function or class method that called the logging code. In the example above, the watchdog type is set as *MyClass::myMethod*.
+The watchdog type is set as the function or class method that called the logging code. In the example above, the watchdog type is set as *MyClass::myMethod*.
 
 ## Controlling log levels
 

--- a/src/DrushLogLevel.php
+++ b/src/DrushLogLevel.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\Log;
+
+use Psr\Log\LogLevel;
+
+
+/**
+ * Provides additional log levels that Drush uses for historical reasons.
+ *
+ * Standard log levels should be preferred.
+ *
+ * @see Drush\Log\LogLevel
+ *
+ */
+class DrushLogLevel extends LogLevel
+{
+    // Things that happen early on.  Like 'notice'
+    const BOOTSTRAP = 'bootstrap';
+    const PREFLIGHT = 'preflight';
+
+    // Notice that the user is cancelling an operation. Like 'warning'
+    const CANCEL = 'cancel';
+
+    // Various 'success' messages.  Like 'notice'
+    const OK = 'ok';
+
+    // Means the command was successful. Should appear at most once
+    // per command (perhaps more if subcommands are executed, though).
+    // Like 'notice'.
+    const SUCCESS = 'success';
+
+    // Batch processes. Like 'notice'
+    const BATCH = 'batch';
+}

--- a/src/DrushLogger.php
+++ b/src/DrushLogger.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\Log;
+
+use Drupal\Log\DrushLogLevel as LogLevel;
+use Psr\Log\AbstractLogger;
+
+
+/**
+ * Provides a Drush logger.
+ *
+ * This is an extension of the actual Logger for Drush that is responsible
+ * for logging messages.
+ *
+ * This logger is designed such that it can be provided to
+ * other libraries that log to a Psr\Log\LoggerInterface.
+ * As such, it takes responsibility for passing log messages
+ * to backend invoke, as necessary (c.f. drush_backend_packet()).
+ *
+ * Drush supports all of the required log levels from Psr\Log\LogLevel,
+ * and also defines its own. See Drupal\Log\DrushLogLevel.
+ *
+ * @see Drush\Log\Logger
+ *
+ */
+class DrushLogger extends AbstractLogger
+{
+    /**
+     * The minimum level of logging to ignore. All events at or below this level
+     * will be ignored. This is a LogLevel constant.
+     *
+     * @var string
+     *
+     */
+    protected $ignore = null;
+
+
+    /**
+     * Constructor
+     *
+     * @param string $ignore_level
+     *   The minimum level of logging to ignore. All events at or below this
+     *   level will be ignored.
+     *
+     */
+    public function __construct($ignore_level = null)
+    {
+        $this->ignore = $ignore_level;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     *
+     */
+    public function log($level, $message, array $context = array())
+    {
+        if (isset($this->ignore) && $level >= $this->ignore) {
+            return;
+        }
+
+        // Convert to old $entry array for b/c calls
+        $entry = $context;
+        $entry['type'] = $level;
+        $entry['message'] = $message;
+
+        // Drush\Log\Logger should take over all of the responsibilities
+        // of drush_log, including caching the log messages and sending
+        // log messages along to backend invoke.
+        // TODO: move these implementations inside this class.
+        $log =& drush_get_context('DRUSH_LOG', array());
+        $log[] = $entry;
+        drush_backend_packet('log', $entry);
+
+        if (drush_get_context('DRUSH_NOCOLOR')) {
+            $red = "[%s]";
+            $yellow = "[%s]";
+            $green = "[%s]";
+        }
+        else {
+            $red = "\033[31;40m\033[1m[%s]\033[0m";
+            $yellow = "\033[1;33;40m\033[1m[%s]\033[0m";
+            $green = "\033[1;32;40m\033[1m[%s]\033[0m";
+        }
+
+        $verbose = drush_get_context('DRUSH_VERBOSE');
+        $debug = drush_get_context('DRUSH_DEBUG');
+
+        switch ($level) {
+            case LogLevel::WARNING :
+            case 'cancel' :
+                $type_msg = sprintf($yellow, $level);
+                break;
+            case 'failed' : // Obsolete; only here in case contrib is using it.
+            case 'error' :
+                $type_msg = sprintf($red, $level);
+                break;
+            case 'ok' :
+            case 'completed' : // Obsolete; only here in case contrib is using it.
+            case 'success' :
+            case 'status': // Obsolete; only here in case contrib is using it.
+                // In quiet mode, suppress progress messages
+                if (drush_get_context('DRUSH_QUIET')) {
+                    return TRUE;
+                }
+                $type_msg = sprintf($green, $level);
+                break;
+            case 'notice' :
+            case 'message' : // Obsolete; only here in case contrib is using it.
+            case 'info' :
+                if (!$verbose) {
+                    // print nothing. exit cleanly.
+                    return TRUE;
+                }
+                $type_msg = sprintf("[%s]", $level);
+                break;
+            default :
+                if (!$debug) {
+                    // print nothing. exit cleanly.
+                    return TRUE;
+                }
+                $type_msg = sprintf("[%s]", $level);
+                break;
+        }
+
+        // When running in backend mode, log messages are not displayed, as they will
+        // be returned in the JSON encoded associative array.
+        if (drush_get_context('DRUSH_BACKEND')) {
+            return;
+        }
+
+        $columns = drush_get_context('DRUSH_COLUMNS', 80);
+
+        $width[1] = 11;
+        // Append timer and memory values.
+        if ($debug) {
+            $timer = sprintf('[%s sec, %s]', round($entry['timestamp']-DRUSH_REQUEST_TIME, 2), drush_format_size($entry['memory']));
+            $entry['message'] = $entry['message'] . ' ' . $timer;
+        }
+
+        $width[0] = ($columns - 11);
+
+        $format = sprintf("%%-%ds%%%ds", $width[0], $width[1]);
+
+        // Place the status message right aligned with the top line of the error message.
+        $message = wordwrap($entry['message'], $width[0]);
+        $lines = explode("\n", $message);
+        $lines[0] = sprintf($format, $lines[0], $type_msg);
+        $message = implode("\n", $lines);
+        drush_print($message, 0, STDERR);
+    }
+
+}


### PR DESCRIPTION
This ports Drush's [built-in PSR-3-compliant logger](https://github.com/drush-ops/drush/tree/master/lib/Drush/Log) allowing its use in Drush commands without having to require the entire Drush library as a dependency. It's mostly the same as Drush's logger, but adds the level ignoring present in `WatchdogLogger`.
