### PR TITLE
Add support for exception logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,15 @@ Log levels below a specified level can be ignored, which may help reduce noise i
     $logger->debug('Some debugging information');
 
 By default, no events are ignored.
+
+## Exception handling
+
+Full logging of exceptions is supported via the `exception` key in the log context array:
+
+    $exception = new \Exception('Example exception.');
+
+    $logger->debug('An exception was thrown.', [
+        'exception' => $exception,
+    ]);
+
+When used, Drupal's `watchdog_exception()` function will be used instead of `watchdog()`.

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ Full logging of exceptions is supported via the `exception` key in the log conte
         'exception' => $exception,
     ]);
 
-When used, Drupal's `watchdog_exception()` function will be used instead of `watchdog()`.
+When used, the equivalent of Drupal's `watchdog_exception()` function will be used instead of `watchdog()`.

--- a/src/WatchdogLogger.php
+++ b/src/WatchdogLogger.php
@@ -88,11 +88,90 @@ class WatchdogLogger extends AbstractLogger
         if (isset($context['exception']) && $context['exception'] instanceof $throwable_class) {
             $exception = $context['exception'];
             unset($context['exception']);
-            watchdog_exception($facility, $exception, $message, $context, $severity);
-        }
-        else {
-            watchdog($facility, $message, $context, $severity);
+            $this->logThrowable($facility, $exception, $message, $context, $severity);
+        } else {
+            $this->watchdog($facility, $message, $context, $severity);
         }
     }
 
+
+    /**
+     * Logs a throwable (exception or error) using watchdog.
+     *
+     * This is equivalent to Drupal's watchdog_exception() with added support
+     * for PHP 7's throwables.
+     *
+     * @param string $type
+     *   The category to which this message belongs.
+     * @param \Throwable|\Exception $throwable
+     *   The throwable that is going to be logged.
+     * @param string|null $message
+     *   The message to store in the log. If empty, a text that contains all useful
+     *   information about the passed-in exception is used.
+     * @param array $variables
+     *   Array of variables to replace in the message on display. Defaults to the
+     *   return value of _drupal_decode_exception().
+     * @param int $severity
+     *   The severity of the message, as per RFC 3164.
+     * @param string $link
+     *   A link to associate with the message.
+     *
+     */
+    protected function logThrowable($type, $exception, $message = null, $variables = [], $severity = WATCHDOG_ERROR, $link = null)
+    {
+        // Use a default value if $message is not set.
+        if (empty($message)) {
+            // The exception message is run through check_plain() by _drupal_decode_exception().
+            $message = '%type: !message in %function (line %line of %file).';
+        }
+
+        // $variables must be an array so that we can add the exception information.
+        if (!is_array($variables)) {
+            $variables = array();
+        }
+
+        require_once DRUPAL_ROOT . '/includes/errors.inc';
+        $variables += _drupal_decode_exception($exception);
+
+        $this->watchdog($type, $message, $variables, $severity, $link);
+    }
+
+
+    /**
+     * Logs a message using Watchdog.
+     *
+     * This is mostly just a wrapper for the watchdog() function.
+     *
+     * @param string $type
+     *   The category to which this message belongs. Can be any string, but the
+     *   general practice is to use the name of the module calling watchdog().
+     * @param string $message
+     *   The message to store in the log. Keep $message translatable
+     *   by not concatenating dynamic values into it! Variables in the
+     *   message should be added by using placeholder strings alongside
+     *   the variables argument to declare the value of the placeholders.
+     *   See t() for documentation on how $message and $variables interact.
+     * @param array $variables
+     *   Array of variables to replace in the message on display or
+     *   NULL if message is already translated or not possible to
+     *   translate.
+     * @param int $severity
+     *   The severity of the message; one of the following values as defined in
+     *   RFC 3164.
+     *   - WATCHDOG_EMERGENCY: Emergency, system is unusable.
+     *   - WATCHDOG_ALERT: Alert, action must be taken immediately.
+     *   - WATCHDOG_CRITICAL: Critical conditions.
+     *   - WATCHDOG_ERROR: Error conditions.
+     *   - WATCHDOG_WARNING: Warning conditions.
+     *   - WATCHDOG_NOTICE: (default) Normal but significant conditions.
+     *   - WATCHDOG_INFO: Informational messages.
+     *   - WATCHDOG_DEBUG: Debug-level messages.
+     * @param string $link
+     *   A link to associate with the message.
+     *
+     */
+    protected function watchdog($type, $message, $variables = [], $severity = WATCHDOG_NOTICE, $link = null)
+    {
+        watchdog($type, $message, $variables, $severity, $link);
+    }
 }

--- a/src/WatchdogLogger.php
+++ b/src/WatchdogLogger.php
@@ -82,7 +82,17 @@ class WatchdogLogger extends AbstractLogger
             $facility = $trace[$index]['class'] . '::' . $facility;
         }
 
-        watchdog($facility, $message, $context, $severity);
+        // \Throwable is PHP 7+ only.
+        $throwable_class = interface_exists('\Throwable') ? \Throwable::class : \Exception::class;
+
+        if (isset($context['exception']) && $context['exception'] instanceof $throwable_class) {
+            $exception = $context['exception'];
+            unset($context['exception']);
+            watchdog_exception($facility, $exception, $message, $context, $severity);
+        }
+        else {
+            watchdog($facility, $message, $context, $severity);
+        }
     }
 
 }

--- a/src/WatchdogLogger.php
+++ b/src/WatchdogLogger.php
@@ -90,7 +90,7 @@ class WatchdogLogger extends AbstractLogger
             unset($context['exception']);
             $this->logThrowable($facility, $exception, $message, $context, $severity);
         } else {
-            $this->watchdog($facility, $message, $context, $severity);
+            watchdog($type, $message, $variables, $severity);
         }
     }
 
@@ -113,11 +113,9 @@ class WatchdogLogger extends AbstractLogger
      *   return value of _drupal_decode_exception().
      * @param int $severity
      *   The severity of the message, as per RFC 3164.
-     * @param string $link
-     *   A link to associate with the message.
      *
      */
-    protected function logThrowable($type, $exception, $message = null, $variables = [], $severity = WATCHDOG_ERROR, $link = null)
+    protected function logThrowable($type, $exception, $message = null, $variables = [], $severity = WATCHDOG_ERROR)
     {
         // Use a default value if $message is not set.
         if (empty($message)) {
@@ -133,45 +131,6 @@ class WatchdogLogger extends AbstractLogger
         require_once DRUPAL_ROOT . '/includes/errors.inc';
         $variables += _drupal_decode_exception($exception);
 
-        $this->watchdog($type, $message, $variables, $severity, $link);
-    }
-
-
-    /**
-     * Logs a message using Watchdog.
-     *
-     * This is mostly just a wrapper for the watchdog() function.
-     *
-     * @param string $type
-     *   The category to which this message belongs. Can be any string, but the
-     *   general practice is to use the name of the module calling watchdog().
-     * @param string $message
-     *   The message to store in the log. Keep $message translatable
-     *   by not concatenating dynamic values into it! Variables in the
-     *   message should be added by using placeholder strings alongside
-     *   the variables argument to declare the value of the placeholders.
-     *   See t() for documentation on how $message and $variables interact.
-     * @param array $variables
-     *   Array of variables to replace in the message on display or
-     *   NULL if message is already translated or not possible to
-     *   translate.
-     * @param int $severity
-     *   The severity of the message; one of the following values as defined in
-     *   RFC 3164.
-     *   - WATCHDOG_EMERGENCY: Emergency, system is unusable.
-     *   - WATCHDOG_ALERT: Alert, action must be taken immediately.
-     *   - WATCHDOG_CRITICAL: Critical conditions.
-     *   - WATCHDOG_ERROR: Error conditions.
-     *   - WATCHDOG_WARNING: Warning conditions.
-     *   - WATCHDOG_NOTICE: (default) Normal but significant conditions.
-     *   - WATCHDOG_INFO: Informational messages.
-     *   - WATCHDOG_DEBUG: Debug-level messages.
-     * @param string $link
-     *   A link to associate with the message.
-     *
-     */
-    protected function watchdog($type, $message, $variables = [], $severity = WATCHDOG_NOTICE, $link = null)
-    {
-        watchdog($type, $message, $variables, $severity, $link);
+        watchdog($type, $message, $variables, $severity);
     }
 }


### PR DESCRIPTION
This adds support for native exception logging (via `watchdog_exception()`) by passing the exception object via the `exception` key inside the context.

PHP 7 throwables are nominally supported as well, but Drupal 7's `watchdog_exception()` does not accept `\Throwable` without a patch.